### PR TITLE
Atomic state management

### DIFF
--- a/.github/workflows/check_codebase.yml
+++ b/.github/workflows/check_codebase.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.7]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/check_codebase.yml
+++ b/.github/workflows/check_codebase.yml
@@ -33,13 +33,13 @@ jobs:
     - name: Check imports with isort
       run: |
         python -m isort --check-only client_code
-        python -m isort --check-only server_code
-    - name: Run test suite
-      run: |
-        python -m pytest
-    - name: Check docs build
-      run: |
-        sphinx-build docs build
+        # python -m isort --check-only server_code
+    # - name: Run test suite
+    #   run: |
+    #     python -m pytest
+    # - name: Check docs build
+    #   run: |
+    #     sphinx-build docs build
     - name: Check version numbering
       run: |
         python -m bumpversion --dry-run patch

--- a/client_code/atomic/__init__.py
+++ b/client_code/atomic/__init__.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021 anvilistas
+
+from .atoms import DictAtom, ListAtom, atom
+from .contexts import ignore_updates
+from .decorators import action, render, render_call, selector, subscribe
+from .helpers import bind, set_debug, writeback
+
+
+@atom
+class Atom:
+    """a simple class that can be instantiated with kws
+    and create a dict like atom with easy attribute access"""
+
+    def __init__(self, **kws):
+        for key, val in kws.items():
+            object.__setattr__(self, key, val)

--- a/client_code/atomic/__init__.py
+++ b/client_code/atomic/__init__.py
@@ -6,6 +6,8 @@ from .contexts import ignore_updates
 from .decorators import action, render, render_call, selector, subscribe
 from .helpers import bind, set_debug, writeback
 
+__version__ = "0.0.1"
+
 
 @atom
 class Atom:

--- a/client_code/atomic/atoms.py
+++ b/client_code/atomic/atoms.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021 anvilistas
+
+from collections import namedtuple
+from functools import partial
+
+from .constants import CHANGE, DELETE, REGISTRAR, SENTINEL
+from .contexts import ActionContext
+from .decorators import action
+from .registrar import add_registrar
+from .rendering import register, request
+from .utils import MethodType, get_atom_prop_repr
+
+
+class BaseAction(
+    namedtuple("_BaseAction", ["action", "atom", "prop", "value"], defaults=[None])
+):
+    """We use this as something we can pass to the action queue and might be consumed by a decorated subscriber"""
+
+    def __str__(self):
+        action, atom, prop, val = self
+        val = f" = {val!r}" if action is CHANGE else ""
+        return f"{action}: {get_atom_prop_repr(atom, prop)}{val}"
+
+
+def as_atom(atom, prop, val):
+    if type(val) is dict:
+        return DictAtom(val)
+    elif type(val) is list:
+        return ListAtom(atom, prop, val)
+    else:
+        return val
+
+
+def atom(base):
+    """decorator for an atom class"""
+
+    class AtomProxy(base):
+        """an AtomProxy requests an update whenever the __setattr__ is called
+        and registers a relationship whenever __getattribute__ is called
+        methods and dunder methods are ignored.
+        """
+
+        __slots__ = REGISTRAR  # slots don't actually work yet
+
+        def __init__(self, *args, **kws):
+            add_registrar(self)
+            base.__init__(self, *args, **kws)
+
+        def __getattribute__(self, name: str):
+            ret = base.__getattribute__(self, name)
+            if not name.startswith("__") and type(ret) is not MethodType:
+                # we ignore all dunder attributes and methods
+                register(self, name)
+            return ret
+
+        def __setattr__(self, name, value):
+            try:
+                if base.__getattribute__(self, name) is value:
+                    return
+            except AttributeError:
+                pass
+            if name.startswith("__"):
+                return base.__setattr__(self, name, value)
+            value = as_atom(self, name, value)
+            with ActionContext(BaseAction(CHANGE, self, name, value)):
+                base.__setattr__(self, name, value)
+                request(self, name)
+
+        def __delattr__(self, name):
+            if name.startswith("__"):
+                base.__delattr__(self, name)
+            with ActionContext(BaseAction(DELETE, self, name)):
+                base.__delattr__(self, name)
+                request(self, name)
+
+        def __repr__(self):
+            if base.__repr__ is object.__repr__:
+                return f"<{base.__name__} atom>"
+            else:
+                return base.__repr__(self)
+
+    AtomProxy.__name__ = base.__name__
+    AtomProxy.__qualname__ = base.__qualname__
+    return AtomProxy
+
+
+class DictAtom(dict):
+    """
+    a DictAtom requests an update whenever the __setitem__ is called
+    and registers a relationship whenever __getitem__ is called
+    """
+
+    __slots__ = REGISTRAR
+
+    def __init__(self, *args, **kws):
+        target = dict(*args, **kws)
+        dict.__init__(self, ((k, as_atom(self, k, v)) for k, v in target.items()))
+        add_registrar(self)
+
+    __hash__ = object.__hash__
+
+    def __getitem__(self, key):
+        res = dict.__getitem__(self, key)
+        register(self, key)
+        return res
+
+    def __setitem__(self, key, val):
+        current = dict.get(self, key, SENTINEL)
+        if current is val:
+            return
+        val = as_atom(self, key, val)
+        with ActionContext(BaseAction(CHANGE, self, key, val)):
+            dict.__setitem__(self, key, val)
+            request(self, key)
+
+    def __delitem__(self, key):
+        self.pop(key)
+
+    def update(self, *args, **kws):
+        for k, v in dict(*args, **kws).items():
+            self[k] = v
+
+    def pop(self, key, default=SENTINEL):
+        if default is SENTINEL:
+            res = dict.pop(self, key)
+        else:
+            res = dict.pop(self, key, SENTINEL)
+            if res is SENTINEL:
+                return default
+        with ActionContext(BaseAction(DELETE, self, key)):
+            request(self, key)
+            return res
+
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def __iter__(self):
+        # prevents dict(self) using the fast internal dict path
+        # which makes it easier to depend on each atom in a list of DictAtoms
+        # by calling [dict(atom) for dict_atom in list_atom]
+        return dict.__iter__(self)
+
+    def __repr__(self):
+        return f"DictAtom({dict.__repr__(self)})"
+
+
+def _method(meth: str, convert_args=None):
+    def fn(self, *args):
+        if convert_args is not None:
+            args = convert_args(self, *args)
+        ret = getattr(list, meth)(self, *args)
+        self._request_render()
+        return ret
+
+    fn.__name__ = meth
+    fn.__qualname__ = "ListAtom." + meth
+    return action(fn)
+
+
+class ListAtom(list):
+    """
+    Any time the list is mutated we request a render from the parent atom at the property this list belongs to
+    """
+
+    slots = ["_as_atom", "_request_render", "_register"]
+
+    def __init__(self, parent_atom, prop, target) -> None:
+        list.__init__(self, (as_atom(parent_atom, prop, t) for t in target))
+        self._as_atom = partial(as_atom, parent_atom, prop)
+        self._request_render = partial(request, parent_atom, prop)
+        self._register = partial(register, parent_atom, prop)
+
+    def __getitem__(self, i):
+        self._register()
+        return list.__getitem__(self, i)
+
+    __setitem__ = _method(
+        "__setitem__",
+        lambda self, i, val: [
+            i,
+            map(self._as_atom, val) if type(i) is slice else self._as_atom(val),
+        ],
+    )
+    __delitem__ = _method("__delitem__")
+    __iadd__ = _method("__iadd__", lambda self, x: [map(self._as_atom, x)])
+    __imul__ = _method("__imul__")
+    extend = _method("extend", lambda self, x: [map(self._as_atom, x)])
+    remove = _method("remove")
+    append = _method("append", lambda self, item: [self._as_atom(item)])
+    insert = _method("insert", lambda self, i, item: [i, self._as_atom(item)])
+    clear = _method("clear")
+    pop = _method("pop")
+    sort = _method("sort")
+    reverse = _method("reverse")
+
+    def __repr__(self):
+        return f"ListAtom({list.__repr__(self)})"

--- a/client_code/atomic/atoms.py
+++ b/client_code/atomic/atoms.py
@@ -11,6 +11,8 @@ from .registrar import add_registrar
 from .rendering import register, request
 from .utils import MethodType, get_atom_prop_repr
 
+__version__ = "0.0.1"
+
 
 class BaseAction(
     namedtuple("_BaseAction", ["action", "atom", "prop", "value"], defaults=[None])

--- a/client_code/atomic/constants.py
+++ b/client_code/atomic/constants.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021 anvilistas
+
+REGISTRAR = "__atom_registrar__"
+
+# MODES
+SELECTOR = "selector"
+ACTION = "action"
+RENDER = "render"
+SUBSCRIBE = "subscriber"
+IGNORE = "ignore"
+
+
+SENTINEL = object()
+CHANGE = "changing"
+DELETE = "deleting"

--- a/client_code/atomic/constants.py
+++ b/client_code/atomic/constants.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2021 anvilistas
 
+__version__ = "0.0.1"
+
 REGISTRAR = "__atom_registrar__"
 
 # MODES

--- a/client_code/atomic/contexts.py
+++ b/client_code/atomic/contexts.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021 anvilistas
+
+from functools import partial
+
+from .constants import ACTION, IGNORE, RENDER, SELECTOR
+from .rendering import active, call_queued, log, queued
+
+
+# ADDERS
+def add_active(to_add, mode, conflicts=(), msg=""):
+    if any(active[m] for m in conflicts):
+        raise RuntimeError(msg)
+    active[mode] += (to_add,)
+
+
+def make_dependent(subscriber):
+    if active[IGNORE]:
+        return
+    actives = active[subscriber.mode]
+    if actives:
+        subscriber.add_dependent(actives[-1])
+
+
+# POP
+def pop_active(mode):
+    actives = active[mode]
+    assert actives, "no " + mode + " to pop"
+    active[mode] = actives[:-1]
+
+
+class Context:
+    """base context"""
+
+    adder = None
+    popper = None
+    mode = None
+
+    def __repr__(self):
+        if type(self.context) is tuple:
+            return repr(self.context)
+        else:
+            return f"{self.mode}: {self.context}"
+
+    def __init__(self, context=None):
+        self.context = context
+
+    def _check_ignore(self):
+        return not active[IGNORE] or self.mode is IGNORE
+
+    def __enter__(self):
+        log(lambda: self)
+        if self._check_ignore():
+            self.adder()
+        return self
+
+    def __exit__(self, *args):
+        if self._check_ignore():
+            self.popper()
+
+
+class IgnoreUpdates(Context):
+    """stops any renders/selectors being queued while updating an atom property
+    This is most useful for lazy loading certain attributes of an atom"""
+
+    def adder(self):
+        active[IGNORE] += (self.context,)
+
+    popper = staticmethod(partial(pop_active, IGNORE))
+    mode = IGNORE
+
+
+ignore_updates = IgnoreUpdates(True)
+
+
+class ActionContext(Context):
+    def adder(self):
+        msg = "Cannot update an Atom or call an action from inside a selector or render method \
+            - use `with ignore_updates:` if you really need to update an Atom attribute"
+        add_active(self.context, ACTION, (SELECTOR, RENDER), msg)
+        queued[ACTION] += (self.context,)
+
+    def popper(self):
+        pop_active(ACTION)
+        if not active[ACTION]:
+            call_queued()
+
+    mode = ACTION
+
+
+class RenderContext(Context):
+    def adder(self):
+        msg = "Cannot call a render method from inside a selector"
+        make_dependent(self.context)
+        add_active(self.context, RENDER, (SELECTOR,), msg)
+
+    popper = staticmethod(partial(pop_active, RENDER))
+    mode = RENDER
+
+
+class SelectorContext(Context):
+    def adder(self):
+        make_dependent(self.context)
+        add_active(self.context, SELECTOR)
+
+    popper = staticmethod(partial(pop_active, SELECTOR))
+    mode = SELECTOR

--- a/client_code/atomic/contexts.py
+++ b/client_code/atomic/contexts.py
@@ -6,6 +6,8 @@ from functools import partial
 from .constants import ACTION, IGNORE, RENDER, SELECTOR
 from .rendering import active, call_queued, log, queued
 
+__version__ = "0.0.1"
+
 
 # ADDERS
 def add_active(to_add, mode, conflicts=(), msg=""):

--- a/client_code/atomic/decorators.py
+++ b/client_code/atomic/decorators.py
@@ -9,6 +9,8 @@ from .registrar import get_registrar
 from .rendering import active, call_queued, queued
 from .subscribers import Render, Selector
 
+__version__ = "0.0.1"
+
 
 def _get_selector(fn, atom, prop):
     atom_registrar = get_registrar(atom)

--- a/client_code/atomic/decorators.py
+++ b/client_code/atomic/decorators.py
@@ -3,7 +3,7 @@
 
 from functools import wraps
 
-from .constants import ACTION, SUBSCRIBE
+from .constants import SUBSCRIBE
 from .contexts import ActionContext
 from .registrar import get_registrar
 from .rendering import active, call_queued, queued

--- a/client_code/atomic/decorators.py
+++ b/client_code/atomic/decorators.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021 anvilistas
+
+from functools import wraps
+
+from .constants import ACTION, SUBSCRIBE
+from .contexts import ActionContext
+from .registrar import get_registrar
+from .rendering import active, call_queued, queued
+from .subscribers import Render, Selector
+
+
+def _get_selector(fn, atom, prop):
+    atom_registrar = get_registrar(atom)
+    s = atom_registrar.selectors.get(prop)
+    if s is None:
+        s = atom_registrar.selectors[prop] = Selector(fn, atom, prop)
+    return s
+
+
+def selector(fn):
+    """decorate a method as a selector whenever it needs to do some computation based on atom attributes
+    This decorate can only be used on an atom method
+    You should never update an atom within a selector
+    A selector can be decorated with @property
+    """
+    prop = fn.__name__
+
+    @wraps(fn)
+    def selector_wrapper(atom):
+        selector = _get_selector(fn, atom, prop)
+        return selector.value
+
+    return selector_wrapper
+
+
+def action(_fn=None, **kws):
+    """Whenever a method does multiple updates use the @action decorator
+    only when the method has finished will renders methods be re-rendered
+    and selector methods be re-computed
+    action can be called with kws like @action(update_db=True)
+    any kws will be added to the action as attributes
+    useful when an action is passed to a function decorated with @susbcribe
+    """
+    if _fn is None:
+        return lambda _fn: action(_fn, **kws)
+    for k, v in kws.items():
+        setattr(_fn, k, v)
+
+    @wraps(_fn)
+    def action_wrapper(*args, **kws):
+        with ActionContext(_fn):
+            _fn(*args, **kws)
+
+    return action_wrapper
+
+
+def subscribe(f):
+    """A subscriber is called after all re-renders resulting from a series of actions
+    a subscriber takes a single argument - the tuple of actions that caused the re-render
+    This might be used to update local storage based on the actions that were performed
+    """
+    active[SUBSCRIBE] += (f,)
+    return f
+
+
+class render:
+    """a decorator typically used above a method in a form
+    if used on a form render methods will only execute on the show event
+    if used as a top level function it can be used to update a database whenever an atom attribute changes
+
+    a render should access all selectors and atom attributes that it depends on
+    i.e. don't access some attributes within branching logic (if statements)
+    """
+
+    def __new__(cls, _fn=None, **kws):
+        if _fn is None:
+            return lambda _fn: render(_fn, **kws)
+        return object.__new__(cls)
+
+    def __init__(self, _fn, bound=None):
+        self.f = _fn
+        self.bound = bound
+
+    def __call__(self, *args, **kws):
+        # each call creates a new renderer
+        return Render(self.f, args, kws, self.bound).render()
+
+    def __get__(self, obj, cls=None):
+        if obj is None:
+            return self
+        method = self.f.__get__(obj, cls)
+        bound = self.bound or obj
+        return render(method, bound=bound)
+
+
+def render_call(f, bound=None):
+    """create a lamba render function and call it straight away
+    optionally provide a component to bind this method to"""
+    if bound is None:
+        try:
+            bound = f.__self__
+        except AttributeError:
+            pass
+    return render(f, bound=bound)()

--- a/client_code/atomic/helpers.py
+++ b/client_code/atomic/helpers.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2021 anvilistas
 
-from functools import lru_cache, partial
+from functools import partial
 
 from .decorators import render_call
 from .rendering import log

--- a/client_code/atomic/helpers.py
+++ b/client_code/atomic/helpers.py
@@ -6,6 +6,8 @@ from functools import lru_cache, partial
 from .decorators import render_call
 from .rendering import log
 
+__version__ = "0.0.1"
+
 
 def set_debug(is_debug=True):
     """if set to true - logging messages will be output to the console"""

--- a/client_code/atomic/helpers.py
+++ b/client_code/atomic/helpers.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021 anvilistas
+
+from functools import lru_cache, partial
+
+from .decorators import render_call
+from .rendering import log
+
+
+def set_debug(is_debug=True):
+    """if set to true - logging messages will be output to the console"""
+    log.is_debug = is_debug
+
+
+def writeback(component, prop, atom_or_selector, attr_or_action=None, events=()):
+    """create a writeback between a component property and an atom attribute
+    or bind the property to an atom selector and call an action when the component property is changed
+    events - should be a single event str or a list of events
+    If no events are provided this is the equivalent of a data-binding with no writeback
+    """
+    atom, attr = atom_or_selector, attr_or_action
+    if type(events) is str:
+        events = [events]
+    if isinstance(atom, dict):
+        assert attr is not None, "if a dict atom is provided the attr must be a str"
+        getter = partial(atom.__getitem__, attr)
+        setter = partial(atom.__setitem__, attr)
+    elif callable(atom):
+        getter = atom
+        setter = attr
+    else:
+        assert attr is not None, "if an atom is provided the attr must be a str"
+        getter = partial(getattr, atom, attr)
+        setter = partial(setattr, atom, attr)
+
+    def render_component():
+        setattr(component, prop, getter())
+
+    render_component.__name__ = render_component.__qualname__ = (
+        type(component).__name__ + "." + prop
+    )
+
+    def do_action(**event_args):
+        setter(getattr(component, prop))
+
+    for event in events:
+        component.add_event_handler(event, do_action)
+
+    render_call(render_component, bound=component)
+
+
+def bind(component, prop, atom_or_selector, attr=None):
+    """create a data-binding between an component property and an atom and its attribute (or a selector)"""
+    # we could support methods here but it's better to be explicit and call selectors inside render methods
+    # accessing an atom property necessarily creates a depenedency on the current render context
+    # so better not to encourage accessing a selector outside of the desired render context
+    return writeback(component, prop, atom_or_selector, attr)

--- a/client_code/atomic/registrar.py
+++ b/client_code/atomic/registrar.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021 anvilistas
+
+from .constants import REGISTRAR, RENDER, SELECTOR
+
+
+class AtomRegistrar:
+    """the registrar is responsible for registering and unregistering atom props to renderers/selectors
+    as well as caching selectors associated with an atom"""
+
+    def __init__(self, atom):
+        self.atom = atom
+        self.to_update = {RENDER: {}, SELECTOR: {}}
+        self.selectors = {}
+
+    def register(self, prop, subscriber, mode):
+        subscriber_set = self.to_update[mode].setdefault(prop, set())
+        if subscriber not in subscriber_set:
+            subscriber_set.add(subscriber)
+            subscriber.register(self, prop)
+            return True
+
+    def unregister(self, prop, subscriber, mode):
+        to_update = self.to_update[mode].get(prop)
+        if to_update is None:
+            return
+        to_update.discard(subscriber)
+        subscriber.unregister(self, prop)
+        if not to_update:
+            self.to_update[mode].pop(prop)
+
+
+_getattr = object.__getattribute__
+_setattr = object.__setattr__
+
+
+def add_registrar(atom):
+    _setattr(atom, REGISTRAR, AtomRegistrar(atom))
+
+
+def get_registrar(atom):
+    return _getattr(atom, REGISTRAR)

--- a/client_code/atomic/registrar.py
+++ b/client_code/atomic/registrar.py
@@ -3,6 +3,8 @@
 
 from .constants import REGISTRAR, RENDER, SELECTOR
 
+__version__ = "0.0.1"
+
 
 class AtomRegistrar:
     """the registrar is responsible for registering and unregistering atom props to renderers/selectors

--- a/client_code/atomic/rendering.py
+++ b/client_code/atomic/rendering.py
@@ -5,6 +5,8 @@ from .constants import ACTION, IGNORE, RENDER, SELECTOR, SUBSCRIBE
 from .registrar import get_registrar
 from .utils import get_atom_prop_repr
 
+__version__ = "0.0.1"
+
 # STATE
 active = {ACTION: (), SELECTOR: (), RENDER: (), SUBSCRIBE: (), IGNORE: ()}
 queued = {SELECTOR: frozenset(), RENDER: frozenset(), ACTION: ()}

--- a/client_code/atomic/rendering.py
+++ b/client_code/atomic/rendering.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021 anvilistas
+
+from .constants import ACTION, IGNORE, RENDER, SELECTOR, SUBSCRIBE
+from .registrar import get_registrar
+from .utils import get_atom_prop_repr
+
+# STATE
+active = {ACTION: (), SELECTOR: (), RENDER: (), SUBSCRIBE: (), IGNORE: ()}
+queued = {SELECTOR: frozenset(), RENDER: frozenset(), ACTION: ()}
+
+
+# LOGGING
+def log(fn):
+    indent = "    " * (
+        len(active[SELECTOR]) + len(active[RENDER]) + len(active[IGNORE])
+    )
+    if log.is_debug:
+        print(f"{indent}{fn()}")
+
+
+log.is_debug = False
+
+
+def register(atom, prop):
+    """if there is an active selector or render
+    we asks the atom registrar to register a relationship between an atom and the attribute being accessed
+    """
+    if active[IGNORE]:
+        return
+    # check selectors first since you can't call a render inside a selctor
+    # but you can call a selector from inside a render
+    if active[SELECTOR]:
+        mode = SELECTOR
+    elif active[RENDER]:
+        mode = RENDER
+    else:
+        return
+    current = active[mode][-1]
+    registrar = get_registrar(atom)
+    registered = registrar.register(prop, current, mode)
+    if registered:
+        log(lambda: f"depends on: {get_atom_prop_repr(atom, prop)}")
+
+
+def remove_atom_prop_relationship(subscriber, mode):
+    """
+    We ask the atom registrar to unregister a relationship between a render and an atom attribute.
+    We only do this with render subscribers.
+    """
+    assert mode is RENDER
+    registrars_props = subscriber.atom_registrar_prop
+    for registrar, prop in registrars_props.copy():
+        registrar.unregister(prop, subscriber, mode)
+
+
+def remove_dependents(root, queue, mode, seen):
+    """
+    take dependents from a root subscriber and remove them from the subscriber queue
+    """
+    if root in seen:
+        return queue
+    seen.add(root)
+    dependents = root.dependents
+    if mode is RENDER:
+        root.dependents = set()
+        remove_atom_prop_relationship(root, mode)
+    if not dependents:
+        return queue
+    queue -= dependents
+    for dependent in dependents:
+        queue = remove_dependents(dependent, queue, mode, seen)
+    return queue
+
+
+def get_to_queue(atom_registrar, prop, mode):
+    """get the renders/selectors that depend on a particular atom attribute"""
+    return frozenset(atom_registrar.to_update[mode].get(prop, []))
+
+
+def queue_subscribers(atom_registrar, prop, mode):
+    """update the current queue of subscribers with a new queue, removing dependent subscribers"""
+    to_queue = get_to_queue(atom_registrar, prop, mode)
+    queue = queued[mode] | to_queue
+    seen = set()
+    for subscriber in to_queue:
+        queue = remove_dependents(subscriber, queue, mode, seen)
+    return queue
+
+
+def request(atom, prop):
+    """when an attribute of an atom is accessed we update the queues based on the subscribers registered"""
+    if active[IGNORE]:
+        return
+    atom_registrar = get_registrar(atom)
+    queued_renders = queue_subscribers(atom_registrar, prop, RENDER)
+    queued_selectors = queue_subscribers(atom_registrar, prop, SELECTOR)
+    queued[RENDER], queued[SELECTOR] = queued_renders, queued_selectors
+
+
+def call_render_queue():
+    """this should call the most parent renders"""
+    queue, queued[RENDER] = queued[RENDER], frozenset()
+    for render in queue:
+        render.render()
+    assert not queued[RENDER]
+
+
+def call_selector_queue():
+    """this will call the most child selector
+    child selectors will then request calls to selectors that depend on them
+    """
+    for _ in range(1000):
+        if not queued[SELECTOR]:
+            return
+        queue, queued[SELECTOR] = queued[SELECTOR], frozenset()
+        for selector in queue:
+            selector.compute()
+    else:
+        raise RuntimeError("Suspected infinite loop from selectors")
+
+
+def call_action_queue():
+    """any registered subscribers will be called after all renders have taken place
+    they get passed a tuple of actions that were used in this render round"""
+    actions, queued[ACTION] = queued[ACTION], ()
+    if not actions:
+        return
+    for subscriber in active[SUBSCRIBE]:
+        subscriber(actions)
+
+
+def call_queued():
+    """calls all the queued subscribers - called after all actions have finished"""
+    selector_queue = queued[SELECTOR]
+    call_selector_queue()
+    render_queue = queued[RENDER]
+    call_render_queue()
+    call_action_queue()
+    if log.is_debug and (selector_queue or render_queue):
+        print()

--- a/client_code/atomic/subscribers.py
+++ b/client_code/atomic/subscribers.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021 anvilistas
+
+from functools import partial
+
+import anvil
+from anvil.js import get_dom_node
+
+from .constants import RENDER, SELECTOR
+from .contexts import RenderContext, SelectorContext, make_dependent
+from .rendering import active, log, register, request
+from .utils import get_atom_prop_repr
+
+
+class Subscriber:
+    """base class knows how to register and unregister"""
+
+    mode = None
+
+    def __init__(self):
+        self.dependents = set()
+        self.atom_registrar_prop = set()
+
+    def add_dependent(self):
+        raise NotImplementedError
+
+    def register(self, atom_registrar, prop):
+        self.atom_registrar_prop.add((atom_registrar, prop))
+
+    def unregister(self, atom_registrar, prop):
+        self.atom_registrar_prop.discard((atom_registrar, prop))
+
+
+class Render(Subscriber):
+    """a render subscriber is created for each call to a decorated render method"""
+
+    mode = RENDER
+
+    def __init__(self, f, args, kws, bound=None):
+        super().__init__()
+        self.f = f
+        self.args = args
+        self.kws = kws
+        self.bound = (
+            bound if bound is not None and isinstance(bound, anvil.Component) else None
+        )
+
+    def add_dependent(self, parent):
+        # I depend on my parent
+        parent.dependents.add(self)
+
+    def maybe_delay(self):
+        bound = self.bound
+        if bound is None:
+            return False
+        try:
+            bound.remove_event_handler("show", self.render)
+        except LookupError:
+            pass
+
+        delay = not get_dom_node(bound).isConnected
+        if delay:
+            bound.add_event_handler("show", self.render)
+        return delay
+
+    def render(self, **event_args):
+        if self.maybe_delay():
+            return
+        with RenderContext(self):
+            self.f(*self.args, **self.kws)
+
+    def __repr__(self):
+        return self.f.__qualname__
+
+
+MISSING = object()
+INITIAL = "initializing"
+CACHE = "using cached"
+RESELECTOR = "recomputing"
+
+
+class Selector(Subscriber):
+    """A Selector subscriber is created once, when an atom calls a selector"""
+
+    mode = SELECTOR
+
+    def __init__(self, f, atom, prop):
+        super().__init__()
+        self.f = f.__get__(atom)
+        self.atom = atom
+        self.prop = prop
+        self.cached = MISSING
+        self.status = INITIAL
+
+    def add_dependent(self, parent):
+        # my parent depends on me
+        self.dependents.add(parent)
+
+    @property
+    def value(self):
+        # anytime our value is requested make renders/selectors depend on our property
+        register(self.atom, self.prop)
+        with SelectorContext(self):
+            if self.cached is MISSING:
+                self.update_cache()
+            return self.cached
+
+    def update_cache(self):
+        self.cached = self.f()
+        self.status = CACHE
+
+    def compute(self):
+        self.status = RESELECTOR
+        with SelectorContext(self):
+            self.update_cache()
+        request(self.atom, self.prop)
+        # the compute happens within an update cycle
+        # i.e. not part of the getattribute mechanism
+        # any computations that depend on us must be requested
+
+    def __repr__(self):
+        return f"{self.status}: {get_atom_prop_repr(self.atom, self.prop)}"

--- a/client_code/atomic/subscribers.py
+++ b/client_code/atomic/subscribers.py
@@ -5,8 +5,8 @@ import anvil
 from anvil.js import get_dom_node
 
 from .constants import RENDER, SELECTOR
-from .contexts import RenderContext, SelectorContext, make_dependent
-from .rendering import active, log, register, request
+from .contexts import RenderContext, SelectorContext
+from .rendering import register, request
 from .utils import get_atom_prop_repr
 
 __version__ = "0.0.1"

--- a/client_code/atomic/subscribers.py
+++ b/client_code/atomic/subscribers.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2021 anvilistas
 
-from functools import partial
-
 import anvil
 from anvil.js import get_dom_node
 
@@ -10,6 +8,8 @@ from .constants import RENDER, SELECTOR
 from .contexts import RenderContext, SelectorContext, make_dependent
 from .rendering import active, log, register, request
 from .utils import get_atom_prop_repr
+
+__version__ = "0.0.1"
 
 
 class Subscriber:

--- a/client_code/atomic/utils.py
+++ b/client_code/atomic/utils.py
@@ -11,9 +11,11 @@ def get_atom_prop_repr(atom, prop):
     return f"{tp_name}.{prop}"
 
 
-class _A:
-    def foo(self):
+# create a fake class to get a method
+# we could import types.MethodType but too much overhead
+class _C:
+    def _m(self):
         pass
 
 
-MethodType = type(_A().foo)
+MethodType = type(_C()._m)

--- a/client_code/atomic/utils.py
+++ b/client_code/atomic/utils.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2021 anvilistas
 
+__version__ = "0.0.1"
+
 
 def get_atom_prop_repr(atom, prop):
     tp_name = type(atom).__name__

--- a/client_code/atomic/utils.py
+++ b/client_code/atomic/utils.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021 anvilistas
+
+
+def get_atom_prop_repr(atom, prop):
+    tp_name = type(atom).__name__
+    if isinstance(atom, dict):
+        return f"{tp_name}[{prop!r}]"
+    return f"{tp_name}.{prop}"
+
+
+class _A:
+    def foo(self):
+        pass
+
+
+MethodType = type(_A().foo)

--- a/server_code/_tmp.py
+++ b/server_code/_tmp.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021 anvilistas

--- a/server_code/_tmp.py
+++ b/server_code/_tmp.py
@@ -1,2 +1,0 @@
-# SPDX-License-Identifier: MIT
-# Copyright (c) 2021 anvilistas


### PR DESCRIPTION
Based on the [mobx js ](https://mobx.js.org/) library and adapted from [mopyx](https://github.com/germaniumhq/mopyx/tree/master/mopyx) library.


**Example usage:**
https://anvil.works/build#clone:IN4YLWJBNNS2HHA6=KS6RVKNVD5IVN3MSKUMBMYCF

**Example code:**
```python
from anvil_labs.atomic import render
from atoms import count_atom

class Count(CountTemplate):
    def __init__(self):
        self.dispaly_count()

    @render
    def display_count(self):
        self.count_lbl.text = count_atom.get_count()

    def neg_btn_click(self, **event_args):
        count_atom.update_count(-1)

    def pos_btn_click(self, **event_args):
        count_atom.update_count(1)

```

```python
from anvil_labs.atomic import atom, action, selector

@atom
class Count:
    value = 0

    @action
    def update_count(self, value):
        self.value += value

    @selector
    def get_count(self):
        return self.value

count_atom = Count()

```

The library aims to move state management to global objects (aka an atoms)
this leave Forms to handle displaying the UI.
since an atom is global any form can import it
this prevents trying to pass state up the form hierarchy

Instead of updating local state in event handlers
call actions on atoms
actions ultimately update the attributes of an atom
the library will then:
- re-compute any selectors that depend on these attributes
- call any render methods that now need re-rendering


**Action** -> **Update State** -> **Re-compute selectors** -> **Call render methods** --> repeat

---

anvil's writebacks don't really play nicely with this library so i've also implemented an alternative
The above code can be written as:

```python
from anvil_labs.atomic import bind

class Count(CountTemplate):
    def __init__(self):
        bind(self.count_lbl, "text", count_atom.get_count)
        # or
        bind(self.count_lbl, "text", count_atom, "value")

```

There's also `writeback`
```python
        writeback(self.check_box_1, "checked", self.item, "completed", events=["change"])
```

#### Limitations
not yet suited to state changes from anvil table rows

#### TODO
- [ ] documentation
