### PR TITLE
make values and items of a dict atom depend on all the values

### DIFF
--- a/client_code/atomic/atoms.py
+++ b/client_code/atomic/atoms.py
@@ -146,6 +146,16 @@ class DictAtom(dict):
         # by calling [dict(atom) for dict_atom in list_atom]
         return dict.__iter__(self)
 
+    def values(self):
+        # maybe silly but if a render method wants to depend on the values
+        # then create a dependency on all the values now
+        [self[k] for k in self]
+        return dict.values(self)
+
+    def items(self):
+        [self[k] for k in self]
+        return dict.items(self)
+
     def __repr__(self):
         return f"DictAtom({dict.__repr__(self)})"
 

--- a/client_code/atomic/decorators.py
+++ b/client_code/atomic/decorators.py
@@ -52,7 +52,7 @@ def action(_fn=None, **kws):
     @wraps(_fn)
     def action_wrapper(*args, **kws):
         with ActionContext(_fn):
-            _fn(*args, **kws)
+            return _fn(*args, **kws)
 
     return action_wrapper
 

--- a/client_code/atomic/subscribers.py
+++ b/client_code/atomic/subscribers.py
@@ -67,7 +67,7 @@ class Render(Subscriber):
         if self.maybe_delay():
             return
         with RenderContext(self):
-            self.f(*self.args, **self.kws)
+            return self.f(*self.args, **self.kws)
 
     def __repr__(self):
         return self.f.__qualname__
@@ -76,7 +76,7 @@ class Render(Subscriber):
 MISSING = object()
 INITIAL = "initializing"
 CACHE = "using cached"
-RESELECTOR = "recomputing"
+RECOMPUTE = "recomputing"
 
 
 class Selector(Subscriber):
@@ -110,7 +110,7 @@ class Selector(Subscriber):
         self.status = CACHE
 
     def compute(self):
-        self.status = RESELECTOR
+        self.status = RECOMPUTE
         with SelectorContext(self):
             self.update_cache()
         request(self.atom, self.prop)


### PR DESCRIPTION
I think this is the right way to do it.

It might seem a bit silly but i wanted to do something with the values of a dict atom but I couldn't depend on the values because it hadn't been overridden

I could wrap it in a check to see if there are any renders/selectors currently active before creating the fake list
