### PR TITLE
non-blocking module idea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Unrelease
+
+## New Features
+- `non_blocking` module - call functions in a non-blocking way
+  https://github.com/anvilistas/anvil-labs/pull/10
+- `atomic` module - state management module
+  https://github.com/anvilistas/anvil-labs/pull/4

--- a/client_code/non_blocking.py
+++ b/client_code/non_blocking.py
@@ -79,7 +79,8 @@ class AsyncCall:
 
 def call_async(fn, *args, **kws):
     "call a function in a non-blocking way"
-    assert callable(fn), "the first argument must be a callable that takes no args"
+    if not callable(fn):
+        raise TypeError("the first argument must be a callable")
     return AsyncCall(fn, *args, **kws)
 
 
@@ -100,20 +101,20 @@ def wait_for(async_call_object):
 
 
 class Interval:
-    """create an interval - T
-    he first argument must a function that takes no arguments
-    The second argument is the delay in seconds.
-    The funciton will be called every delay seconds.
+    """create an interval
+    The first argument must a function that takes no arguments
+    The second argument is the interval in seconds.
+    The funciton will be called every interval seconds.
     To stop the interval either set its interval to None or 0 or call the clear_interval() method
     """
 
-    def __init__(self, fn, delay=None):
+    def __init__(self, fn, interval=None):
         assert callable(
             fn
         ), "the first argument to interval must be a callable that takes no arguments"
         self._id = None
         self._fn = fn
-        self.interval = delay
+        self.interval = interval
 
     @property
     def interval(self):

--- a/client_code/non_blocking.py
+++ b/client_code/non_blocking.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2021 anvilistas
+
+from functools import partial as _partial
+
+from anvil.js import await_promise as _await_promise
+from anvil.js import window as _W
+from anvil.server import call_s as _call_s
+
+__version__ = "0.0.1"
+
+_sentinel = object()
+try:
+    # just for a nice repr by default
+    _call_s.__name__ = "call_s"
+    _call_s.__qualname__ = "anvil.server.call_s"
+except AttributeError:
+    pass
+
+# python errors get wrapped when called from a js function in python
+# so instead reject the error from a js function in js
+_promise_handler = _W.Function(
+    "fn",
+    """
+return (resolve, reject) => {
+    try {
+        resolve(fn());
+    } catch (e) {
+        reject(e);
+    }
+}
+""",
+)
+
+
+class AsyncCall:
+    def __init__(self, fn, *args, **kws):
+        fn = _partial(fn, *args, **kws)
+        self._orig = fn
+        self._update_promise(fn)
+
+    def on_result(self, result_handler, error_handler=None):
+        self._update_promise(self._get_new_fn(result_handler, error_handler))
+        return self
+
+    def on_error(self, error_handler):
+        self._update_promise(self._get_new_fn(None, error_handler))
+        return self
+
+    def _update_promise(self, fn):
+        self._promise = _W.Promise(_promise_handler(fn))
+
+    def _get_new_fn(self, result_handler=None, error_handler=None):
+        def new_fn():
+            res = err = _sentinel
+            try:
+                res = _await_promise(self._promise)
+            except Exception as e:
+                err = e
+            if res is not _sentinel:
+                if result_handler is None:
+                    return res
+                else:
+                    return result_handler(res)
+            elif error_handler:
+                return error_handler(err)
+            else:
+                raise err
+
+        return new_fn
+
+    def wait(self):
+        return _await_promise(self._promise)
+
+    def __repr__(self):
+        fn_repr = repr(self._orig).replace("functools.partial", "")
+        return f"<non_blocking.AsyncCall{fn_repr}>"
+
+
+def call_async(fn, *args, **kws):
+    "call a function in a non-blocking way"
+    assert callable(fn), "the first argument must be a callable that takes no args"
+    return AsyncCall(fn, *args, **kws)
+
+
+def call_server_async(fn_name, *args, **kws):
+    "call a server function in a non_blocking way"
+    if not type(fn_name) is str:
+        raise TypeError("the first argument must be the server function name as a str")
+    return AsyncCall(_call_s, fn_name, *args, **kws)
+
+
+def wait_for(async_call_object):
+    "wait for a non-blocking function to complete its execution"
+    if not isinstance(async_call_object, AsyncCall):
+        raise TypeError(
+            f"expected an AsyncCall object, got {type(async_call_object).__name__}"
+        )
+    return async_call_object.wait()
+
+
+class Interval:
+    """create an interval - T
+    he first argument must a function that takes no arguments
+    The second argument is the delay in seconds.
+    The funciton will be called every delay seconds.
+    To stop the interval either set its interval to None or 0 or call the clear_interval() method
+    """
+
+    def __init__(self, fn, delay=None):
+        assert callable(
+            fn
+        ), "the first argument to interval must be a callable that takes no arguments"
+        self._id = None
+        self._fn = fn
+        self.interval = delay
+
+    @property
+    def interval(self):
+        return self._delay
+
+    @interval.setter
+    def interval(self, value):
+        if value is not None and not isinstance(value, (int, float)):
+            raise TypeError(f"cannot set interval to be of type {type(value).__name__}")
+        self._delay = value
+        _W.clearInterval(self._id)
+        if not value:
+            return
+        self._id = _W.setInterval(self._fn, value * 1000)
+
+    def clear_interval(self):
+        self.interval = None

--- a/docs/guides/modules/non_blocking.rst
+++ b/docs/guides/modules/non_blocking.rst
@@ -1,0 +1,127 @@
+NonBlocking
+===========
+
+Call function in a non-blocking way.
+
+Examples
+--------
+
+Call a server function
+**********************
+
+After making updates on the client, call a server function to update the database.
+In this example, we don't care about the return.
+
+
+.. code-block:: python
+
+    from anvil_labs.non_blocking import call_server_async
+
+    def button_click(self, **event_args):
+        self.update_database()
+        self.open_form("Form1")
+
+    def update_database(self):
+        # Unlike anvil.server.call we do not wait for the call to return
+        call_server_async("update", self.item)
+
+
+If you care about the return value, you can provide handlers.
+
+.. code-block:: python
+
+    from anvil_labs.non_blocking import call_server_async
+
+    def handle_result(self, res):
+        print(res)
+        Notification("successfully saved").show()
+
+    def handle_error(self, err):
+        print(err)
+        Notification("there was a problem", style="danger").show()
+
+    def update_database(self, **event_args):
+        call_server_async("update", self.item).on_result(self.handle_result, self.handle_error)
+        # Equivalent to
+        _ = call_server_async("update", self.item)
+        _.on_result(self.handle_result, self.handle_result)
+        # Equivalent to
+        _ = call_server_async("update", self.item)
+        _.on_result(self.handle_result)
+        _.on_error(self.handle_error)
+
+
+Interval
+********
+
+Create a Timer-like object in code without worrying about components.
+
+.. code-block:: python
+
+    from anvil_labs.non_blocking import Interval
+
+    i = 0
+    def do_heartbeat():
+        global heartbeat, i
+        if i >= 100:
+            heartbeat.interval = 0
+        print("da dum")
+        i += 1
+
+    heartbeat = Interval(do_heartbeat, 1)
+
+
+
+
+API
+---
+
+.. function:: call_async(fn, *args, **kws)
+
+    Returns an ``AyncCall`` object. The *fn* will be called in a non-blocking way.
+
+.. function:: call_server_async(fn_name, *args, **kws)
+
+    Returns an ``AyncCall`` object. The server function will be called in a non-blocking way.
+
+.. function:: wait_for(async_call_object)
+
+    Blocks until the ``AsyncCall`` object has finished executing.
+
+.. class:: AyncCall
+
+    Don't call this directly, instead use the above functions.
+
+    .. method:: on_result(self, result_handler, error_handler=None)
+
+        Provide a result handler to handle the return value of the non-blocking call.
+        Provide an optional error handler to handle the error if the non-blocking call raises an exception.
+        Both handlers should take a single argument.
+
+        Returns ``self``.
+
+    .. method:: on_error(self, error_handler)
+
+        Provide an error handler that will be called if the non-blocking call raises an exception.
+        The handler should take a single argument, the exception to handle.
+
+        Returns ``self``.
+
+    .. method:: wait(self)
+
+        Waits for the non-blocking call to finish executing and returns the result.
+
+
+.. class:: Interval(fn, interval=None)
+
+    Create an interval that will call a function every delay seconds.
+    If the delay is ``0`` or ``None`` the Interval will stop calling the function.
+
+    .. attribute:: interval
+
+        change the interval to ``None`` or an ``int`` / ``float`` in seconds.
+        If the interval is ``None`` or ``0``, the function will no longer fire.
+
+    .. method:: clear_interval(self)
+
+        Equivalent to ``my_interval.interval = None``


### PR DESCRIPTION
My use case was to call a server function in a non-blocking way

```python
from anvil_labs.non_blocking import call_server_async

call_server_async("update_db", local_changes)

```

and then I got carried away

```python
from anvil_labs.non_blocking import call_server_async

def handle_result(self, res):
     alert(res)

def handle_error(self, err):
    print(err)
...

x = call_server_async("get_something")
x.on_result(self.handle_result, self.handle_err)
# equivalent to
x.on_result(self.handle_result)
x.on_error(self.handle_error)

```

And then since we're playing with non-blocking code why not include an Interval class

```python
from anvil_labs.non_blocking import Interval

def do_heart_beat():
    print("beating")

heart_beat = Interval(do_heart_beat, 1)
```


