### PR TITLE
Atomic updates

### DIFF
--- a/client_code/atomic/__init__.py
+++ b/client_code/atomic/__init__.py
@@ -3,7 +3,7 @@
 
 from .atoms import DictAtom, ListAtom, atom
 from .contexts import ignore_updates
-from .decorators import action, render, render_call, selector, subscribe
+from .decorators import action, autorun, render, selector, subscribe
 from .helpers import bind, set_debug, writeback
 
 __version__ = "0.0.1"

--- a/client_code/atomic/decorators.py
+++ b/client_code/atomic/decorators.py
@@ -97,9 +97,9 @@ class render:
         return render(method, bound=bound)
 
 
-def render_call(f, bound=None):
-    """create a lamba render function and call it straight away
-    optionally provide a component to bind this method to"""
+def autorun(f, bound=None):
+    """create render function that is called immediately.
+    Optionally provide a component to bind this method to"""
     if bound is None:
         try:
             bound = f.__self__

--- a/client_code/atomic/helpers.py
+++ b/client_code/atomic/helpers.py
@@ -3,7 +3,7 @@
 
 from functools import partial
 
-from .decorators import render_call
+from .decorators import autorun
 from .rendering import log
 
 __version__ = "0.0.1"
@@ -48,7 +48,7 @@ def writeback(component, prop, atom_or_selector, attr_or_action=None, events=())
     for event in events:
         component.add_event_handler(event, do_action)
 
-    render_call(render_component, bound=component)
+    autorun(render_component, bound=component)
 
 
 def bind(component, prop, atom_or_selector, attr=None):

--- a/client_code/atomic/subscribers.py
+++ b/client_code/atomic/subscribers.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2021 anvilistas
 
 import anvil
-from anvil.js import get_dom_node
 
 from .constants import RENDER, SELECTOR
 from .contexts import RenderContext, SelectorContext
@@ -60,7 +59,9 @@ class Render(Subscriber):
             pass
 
         delay = (
-            not get_dom_node(bound).isConnected and not immediate and not active[RENDER]
+            not anvil.js.get_dom_node(bound).isConnected
+            and not immediate
+            and not active[RENDER]
         )
         if delay:
             bound.add_event_handler("show", self.render)

--- a/docs/guides/modules/atomic.rst
+++ b/docs/guides/modules/atomic.rst
@@ -1,0 +1,451 @@
+Atomic
+======
+
+Object-oriented state management.
+The aim is to separate the state from the UI.
+Atoms manage the state.
+A form now has two jobs. It displays the state and hooks up events (like button clicks) to actions.
+The atom's job is to manage the state.
+Each atom is a global object, which any form can import.
+By eliminating state from forms, there is no need to pass state up and down the form hierarchy.
+It also makes testing easier, since we can test atoms in isolation.
+
+
+Examples
+--------
+
+Some examples can be found at in this `clone link <https://anvil.works/build#clone:IN4YLWJBNNS2HHA6=KS6RVKNVD5IVN3MSKUMBMYCF>`_.
+
+Counter
+*******
+
+
+.. code-block:: python
+
+    # Create an atom that holds state
+    from anvil_labs.atomic import atom, action, selector
+
+    @atom
+    class CountAtom:
+        value = 0
+
+        @selector
+        def get_count(self):
+            return self.value
+
+        @action
+        def update_count(self, increment):
+            self.value += increment
+
+    count_atom = CountAtom()
+
+.. code-block:: python
+
+    # Create a form to display the count
+    from anvil_labs.atomic import render
+    from ..atoms.count import count_atom
+
+    class Count(CountTemplate):
+        def __init__(self):
+            self.display_count()
+
+        @render
+        def display_count(self):
+            # I get called any time the get_count return value changes
+            self.count_lbl.text = count_atom.get_count()
+
+        def neg_btn_click(self, **event_args):
+            count_atom.update_count(-1)
+
+        def pos_btn_click(self, **event_args):
+            count_atom.update_count(1)
+
+
+In this example, whenever a button is clicked:
+
+* the button event handler calls an ``action`` on the atom,
+* which updates the state of the atom,
+* which then updates any ``selectors`` that depend on that state change; and finally,
+* any ``render`` methods that depend on those updates are re-rendered.
+
+
+**Action** → **State change** → **Re-compute selectors** → **Call render methods**
+
+
+Terminology
+-----------
+
+Action
+******
+
+An action is an expression/statement that updates the state of an atom.
+Whenever the state changes, the atomic module invokes a render cycle.
+We probably don't want each state change to invoke a render cycle;
+sometimes it makes sense to combine state updates into a single action.
+To combine actions into a single action, use the ``@action`` decorator.
+Using the ``@action`` decorator means that the render cycle will only be invoked
+after all actions within the decorated function have been completed.
+The ``@action`` decorator can be used on any function and does not necessarily
+need to be a method of an atom.
+
+Selector
+********
+
+A ``selector`` is a method of an atom that returns a value based on the atom's state.
+Essentially it is a getter method.
+When a ``selector`` needs to do something expensive,
+by say, combining various attributes of an atom, use the ``@selector`` decorator.
+The return value from a decorated selector method is cached.
+Whenever the atoms state changes, if the selector depends on that state,
+the selector's return value will be re-computed.
+
+You should never update the state (call an action) within a ``selector``.
+
+Render
+******
+
+A ``render`` is any method/function that depends on the state of an atom,
+or that depends on the return value of a ``selector``.
+
+It's most commonly used on methods within forms, but a ``render`` can be used
+outside of a form.
+
+.. code-block:: python
+
+    from anvil.js.window import document
+    from anvil_labs.atomic import render
+
+    @render
+    def update_tab_title():
+        document.title = count_atom.get_count()
+
+    update_tab_title()
+
+Note we might want to do this with the ``autorun`` function.
+The above example is equivalent to.
+
+.. code-block:: python
+
+    from anvil_labs.atomic import autorun
+
+    def update_tab_title():
+        document.title = count_atom.get_count()
+
+    autorun(update_tab_title)
+
+
+
+
+To depend on the state of an atom, the
+``render`` method must explicitly access that state.
+
+
+.. code-block:: python
+
+    # BAD Example
+    class Count(CountTemplate):
+        def __init__(self):
+            self.display_count(count_atom.value)
+
+        @render
+        def display_count(self):
+            self.count_lbl.text = count
+
+In the above example, the ``display_count`` method does not explicitly access the ``count_atom.value`` attribute.
+This means it does **not** depend on this attribute. The code should look like this:
+
+.. code-block:: python
+
+    # GOOD Example
+    class Count(CountTemplate):
+        def __init__(self):
+            self.display_count()
+
+        @render
+        def display_count(self, count):
+            self.count_lbl.text = count_atom.value
+
+
+
+Accessing an attribute/selector implicitly subscribes the ``render`` method to changes in the state of those attributes/selectors.
+Any time one of these attributes changes, the ``render`` method is invoked (re-rendered).
+
+You should never update the state (call an action) within a ``render`` method.
+
+If the render method is called by a component, it will only execute when the form is on the screen.
+This prevents renders from happening for cached forms, or forms that are no longer active.
+
+Atom
+****
+
+An ``atom`` is any object that knows how to register subscribers and request renders.
+To create an atom, use the ``@atom`` decorator.
+
+Whenever an attribute of an ``atom`` is a ``list`` or ``dict``,
+the attribute will be converted to a ``ListAtom`` or ``DictAtom``.
+Each is a subclass of ``list``/ ``dict`` and behave as you'd expect.
+The only difference is that these classes know how to register subscribers and request renders when their state changes.
+
+
+Subscriber
+**********
+
+A subscriber is an advanced feature. It's the final part of the render cycle.
+After all renders have been completed any subscribers that were decorated with the ``@subscribe``
+decorator will be called. A subscriber takes a single argument, a tuple of actions that were called to invoke the render cycle.
+
+A reason to use a subscriber might be to update storage based on an action that was invoked.
+
+Here's an example.
+
+.. code-block:: python
+
+    from anvil_extras.storage import indexed_db
+    from anvil_labs.atomic import atom, action, subscribe
+
+    @atom
+    class Todos:
+        def __init__(self):
+            self.todos = indexed_db.get("todos", [])
+
+        @action(update_db=True)
+        def add_todo(self, todo):
+            self.todos = self.todos + [todo]
+
+
+    todos_atom = Todos()
+
+    @subscribe
+    def update_db_subscriber(actions):
+        if any(hasattr(action, "update_db") for action in actions):
+            indexed_db["todos"] = todos_atom.todos
+
+
+
+
+
+Bindings and Writeback
+----------------------
+
+It's not recommended to use anvil writebacks and data bindings with atoms.
+This is because we can't control the render cycle.
+
+Instead, there are two helper functions to create bindings and writebacks in code.
+
+.. code-block:: python
+
+    from anvil_labs.atomic import bind
+
+    class Count(CountTemplate):
+        def __init__(self):
+            bind(self.count_lbl, "text", count_atom.get_count)
+            # or bind it to an attribute of an atom
+            bind(self.count_lbl, "text", count_atom, "value")
+
+
+The bind method is equivalent to:
+
+.. code-block:: python
+
+    def bind(component, prop, atom_or_selector, attr=None):
+        @render(bound=component)
+        def render_bind():
+            if callable(atom_or_selector):
+                setattr(component, prop, atom_or_selector())
+            elif isinstance(atom_or_selector, dict):
+                setattr(component, prop, atom_or_selector[attr])
+            else:
+                setattr(component, prop, getattr(atom_or_selector, attr))
+
+        render_bind()
+
+Note the render decorator can take a bound parameter.
+This means that the render won't fire if the component is not on the screen.
+This is not necessary when using the render decorator on a form method.
+
+A writeback is similar to a bind, but a list of events must be provided.
+
+
+.. code-block:: python
+
+
+    writeback(self.check_box, "checked", self.item, "completed", events=["change"])
+
+
+Alternatively, the writeback can be called with a selector in place of the atom and an action in place of the atom attribute.
+If the selector/action call signature is used, the action must take a single argument (the updated property of the component).
+
+.. code-block:: python
+
+    writeback(component, prop, atom, attr, events)
+    writeback(component, prop, selector, action, events)
+
+
+
+
+API
+---
+
+.. function:: set_debug(debug=False)
+
+    Show logging output for the module
+
+.. decorator:: atom
+
+    Create an atom class. An atom class knows how to register subscribers and
+    request re-renders when its state changes.
+
+.. decorator:: render
+               render(bound=None)
+
+    Use the ``render`` decorator anytime you want a function to depend on atom attributes or selectors.
+    In a ``render`` method the attributes must be accessed explicitly.
+    Whenever one of the attributes of the atom changes, the ``render`` method will be invoked.
+
+
+.. decorator:: action
+               action(**kws)
+
+    The action decorator should be used above any method that you want to combine actions into a single action.
+    A base action changes the state of an atom.
+    When calling a function decorated with the ``@action`` decorator, the render cycle will be invoked only after
+    all actions within the function have been executed.
+    It's worth noting that the decorator doesn't need to be used unless you want to combine state updates into a single action.
+    In the counter example, the action decorator is unnecessary, since there is only a single
+    state update within the function (updating the ``.value`` property)
+
+.. decorator:: selector
+
+    The selector decorator can only be used on methods within an atom. Its utility is caching the return value and
+    a selector subscribes to atom attributes in a similar way to renders.
+    If any attribute changes, the cached value will be re-computed.
+    It's worth noting that the selector decorator is unnecessary on methods where accessing the attribute is cheap.
+    In the counter example, the selector is unnecessary and adds little to the implementation.
+
+.. function:: autorun(fn)
+              autorun(fn, bound=None)
+
+    equivalent to ``render(fn)()``.
+
+.. class:: DictAtom
+
+    A subclass of ``dict``. Any attribute within an atom that is a ``dict`` will be converted to a ``DictAtom``.
+    This allows render methods to depend on keys of dicts within the atom's state.
+
+.. class:: ListAtom
+
+    A subclass of ``list``. Any attribute within an atom that is a ``list`` will be converted to a ``ListAtom``.
+    Renders that depend on the ``ListAtom`` will only be invoked if the ``ListAtom`` changes
+    through methods like ``remove()``, ``clear()`` etc.
+
+.. class:: Atom(**kws)
+
+    A simple class that can be called with kwargs. Each kwarg will become an attribute of the atom.
+    Useful if you prefer to access attributes rather than keys of a ``DictAtom``.
+
+
+.. attribute:: ignore_updates
+
+    This can be used as a context manager (using ``with``) to update an atom without invoking a render cycle.
+    A reason to use this decorator is to lazy load an atom property.
+    Use with caution.
+
+
+
+Gotchas and advanced concepts
+-----------------------------
+
+My component isn't updating
+***************************
+
+Make sure that you have used the render decorator and that you have called this method from the ``__init__`` function.
+
+Why don't you use ``self.init_components(**properties)`` in the example?
+************************************************************************
+
+The primary job of ``init_components`` is to set up data bindings.
+But since we don't have any data bindings, we don't need to use this method.
+Note that ``init_components`` does more work when used within a custom component.
+
+
+How do I lazy load an attribute?
+********************************
+
+You can use the ``ignore_updates`` decorator to prevent actions invoking render cycles.
+And since calling an action within a render or selector is not allowed it becomes necessary.
+
+.. code-block:: python
+
+    import anvil.server
+    from anvil_labs.atomic import atom, ignore_updates, selector
+
+    @atom
+    class Todos:
+        def __init__(self):
+            self._todos = None
+
+        @property
+        @selector
+        def todos(self):
+            if self._todos is None:
+                with ignore_updates:
+                    self._todos = anvil.server.call("get_todos")
+            return self._todos
+
+
+Alternatively, you can call an action, ensuring that the action is not called inside a render/selector
+
+.. code-block:: python
+
+    from atoms import todos_atom
+
+    class Form1(Form1Template):
+        def __init__(self, **properties):
+            # fetch_todos is an action that calls the server if it needs to
+            todos_atom.fetch_todos()
+            self.display_todos()
+
+
+
+My UI is taking a long time to update
+*************************************
+
+That might be because you are calling a server function within an action.
+The fetch example is a good example of how to update the UI while you make a call.
+
+.. code-block:: python
+
+    @atom
+    class Fetch:
+        value = None
+        loading = False
+
+        @action
+        def set_status(self, value, loading=False):
+            self.value = value
+            self.loading = loading
+
+        def do_fetch(self):
+            self.set_status(None, loading=True)
+            ret = anvil.server.call_s("do_fetch")
+            self.set_status(ret, loading=False)
+
+        @selector
+        def get_info(self):
+            return self.value, self.loading
+
+
+    fetch_atom = Fetch()
+
+
+``do_fetch`` is not an action, but ``set_status`` is an action.
+``set_status`` is cheap and so the UI updates quickly.
+Each call to ``set_status`` invokes a render cycle.
+When ``loading`` is ``True`` the UI can disable a button while we call the server function.
+
+
+
+How do I work with anvil data tables?
+************************************
+
+We're working on it.


### PR DESCRIPTION
changes:

Commit 1:
``render_call`` -> ``autorun`` (mobx uses autorun)

Commit 2:
remove the anvil.js.get_dom_node import.
I think this will make testing possible on an atom in isolation.
I don't think you can import ``get_dom_node`` locally.

Commit 3:
Add some documentation.