### PR TITLE
atomic: portable atoms

### DIFF
--- a/client_code/atomic/__init__.py
+++ b/client_code/atomic/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2021 anvilistas
 
-from .atoms import DictAtom, ListAtom, atom
+from .atoms import DictAtom, ListAtom, atom, portable_atom
 from .contexts import ignore_updates
 from .decorators import action, autorun, render, selector, subscribe
 from .helpers import bind, set_debug, writeback
@@ -9,10 +9,11 @@ from .helpers import bind, set_debug, writeback
 __version__ = "0.0.1"
 
 
-@atom
+@portable_atom
 class Atom:
-    """a simple class that can be instantiated with kws
-    and create a dict like atom with easy attribute access"""
+    """a portable atom class that can be instantiated with kws.
+    Create a dict like atom with easy attribute access
+    e.g. todo_atom = Atom(done=False, description='walk the dog')"""
 
     def __init__(self, **kws):
         for key, val in kws.items():

--- a/client_code/atomic/atoms.py
+++ b/client_code/atomic/atoms.py
@@ -4,6 +4,8 @@
 from collections import namedtuple
 from functools import partial
 
+from anvil.server import portable_class
+
 from .constants import CHANGE, DELETE, IS_SERVER_SIDE, REGISTRAR, SENTINEL
 from .contexts import ActionContext
 from .decorators import action
@@ -96,6 +98,16 @@ def atom(base):
     AtomProxy.__name__ = base.__name__
     AtomProxy.__qualname__ = base.__qualname__
     AtomProxy.__module__ = base.__module__
+
+    # TODO do we need to think about the name argument here?
+    portable_class(AtomProxy)
+
+    if not hasattr(AtomProxy, "__serialize__"):
+        # TODO remove this when skulpt has __slots__
+        AtomProxy.__serialize__ = lambda self, _: {
+            k: v for k, v in self.__dict__.items() if k != REGISTRAR
+        }
+
     return AtomProxy
 
 

--- a/client_code/atomic/atoms.py
+++ b/client_code/atomic/atoms.py
@@ -98,17 +98,23 @@ def atom(base):
     AtomProxy.__name__ = base.__name__
     AtomProxy.__qualname__ = base.__qualname__
     AtomProxy.__module__ = base.__module__
+    return AtomProxy
 
-    # TODO do we need to think about the name argument here?
-    portable_class(AtomProxy)
 
-    if not hasattr(AtomProxy, "__serialize__"):
+def portable_atom(_cls, name=None):
+    """decorator to for atoms that you also want to be portable classes"""
+    if IS_SERVER_SIDE:
+        return portable_class(_cls, name)
+    elif name is None and type(_cls) is str:
+        name = _cls
+        return lambda _cls: portable_atom(_cls, name)
+
+    if not hasattr(_cls, "__serialize__"):
         # TODO remove this when skulpt has __slots__
-        AtomProxy.__serialize__ = lambda self, _: {
+        _cls.__serialize__ = lambda self, _: {
             k: v for k, v in self.__dict__.items() if k != REGISTRAR
         }
-
-    return AtomProxy
+    return portable_class(_cls, name)
 
 
 KEYS = "dict.KEYS"

--- a/client_code/atomic/decorators.py
+++ b/client_code/atomic/decorators.py
@@ -3,7 +3,7 @@
 
 from functools import wraps
 
-from .constants import SUBSCRIBE
+from .constants import IS_SERVER_SIDE, SUBSCRIBE
 from .contexts import ActionContext
 from .registrar import get_registrar
 from .rendering import active, call_queued, queued
@@ -33,7 +33,7 @@ def selector(fn):
         selector = _get_selector(fn, atom, prop)
         return selector(*args, **kws)
 
-    return selector_wrapper
+    return fn if IS_SERVER_SIDE else selector_wrapper
 
 
 def action(_fn=None, **kws):
@@ -55,7 +55,7 @@ def action(_fn=None, **kws):
             res = _fn(*args, **kws)
         return res
 
-    return action_wrapper
+    return _fn if IS_SERVER_SIDE else action_wrapper
 
 
 def subscribe(f):
@@ -79,7 +79,7 @@ class render:
     def __new__(cls, _fn=None, **kws):
         if _fn is None:
             return lambda _fn: render(_fn, **kws)
-        return object.__new__(cls)
+        return _fn if IS_SERVER_SIDE else object.__new__(cls)
 
     def __init__(self, _fn, bound=None):
         self.f = _fn

--- a/docs/guides/modules/atomic.rst
+++ b/docs/guides/modules/atomic.rst
@@ -295,6 +295,11 @@ API
     Create an atom class. An atom class knows how to register subscribers and
     request re-renders when its state changes.
 
+.. decorator:: portable_atom
+
+    Create an atom class which is also a portable class. It is recommended to use the
+    ``@portable_atom`` decorator over a combination of ``@atom`` and ``@portable_class``.
+
 .. decorator:: render
                render(bound=None)
 
@@ -340,8 +345,10 @@ API
 
 .. class:: Atom(**kws)
 
-    A simple class that can be called with kwargs. Each kwarg will become an attribute of the atom.
+    A portable atom class that can be called with kwargs. Each kwarg will become an attribute of the atom.
     Useful if you prefer to access attributes rather than keys of a ``DictAtom``.
+
+    e.g. ``todo_atom = Atom(done=False, description='walk the dog')``
 
 
 .. attribute:: ignore_updates


### PR DESCRIPTION
close #27

I've made the decorators dummy decorators if we're on the server

Some API questions:
We could use a decorator - `@portable_atom`

I've made all atoms portable classes that use the default name argument
This would be a problem if someone decides to use custom names because they're doing stuff on uplink
But there's no public api for accessing a portable_class's registered name information
So I can't really see a way around this - apart from using a custom `@portable_atom` decorator

