### PR TITLE
Support catching the atom in a subscribe hook

### DIFF
--- a/client_code/atomic/atoms.py
+++ b/client_code/atomic/atoms.py
@@ -51,6 +51,7 @@ def atom(base):
         """
 
         __slots__ = REGISTRAR  # slots don't actually work yet
+        __is_atom__ = True
 
         def __new__(cls, *args, **kws):
             base_new = base.__new__
@@ -139,6 +140,7 @@ class DictAtom(dict):
     """
 
     __slots__ = REGISTRAR
+    __is_atom__ = True
 
     def __init__(self, *args, **kws):
         target = dict(*args, **kws)
@@ -243,7 +245,8 @@ class ListAtom(list):
     Any time the list is mutated we request a render from the parent atom at the property this list belongs to
     """
 
-    slots = ["_as_atom", "_request_render", "_register"]
+    __slots__ = ["_as_atom", "_request_render", "_register"]
+    __is_atom__ = True
 
     def __init__(self, parent_atom, prop, target) -> None:
         list.__init__(self, (as_atom(parent_atom, prop, t) for t in target))

--- a/client_code/atomic/decorators.py
+++ b/client_code/atomic/decorators.py
@@ -6,8 +6,9 @@ from functools import wraps
 from .constants import IS_SERVER_SIDE, SUBSCRIBE
 from .contexts import ActionContext
 from .registrar import get_registrar
-from .rendering import active, call_queued, queued
+from .rendering import active
 from .subscribers import Render, Selector
+from .utils import MethodType, is_atom
 
 __version__ = "0.0.1"
 
@@ -36,7 +37,7 @@ def selector(fn):
     return fn if IS_SERVER_SIDE else selector_wrapper
 
 
-def action(_fn=None, **kws):
+class action:
     """Whenever a method does multiple updates use the @action decorator
     only when the method has finished will renders methods be re-rendered
     and selector methods be re-computed
@@ -44,18 +45,37 @@ def action(_fn=None, **kws):
     any kws will be added to the action as attributes
     useful when an action is passed to a function decorated with @susbcribe
     """
-    if _fn is None:
-        return lambda _fn: action(_fn, **kws)
-    for k, v in kws.items():
-        setattr(_fn, k, v)
 
-    @wraps(_fn)
-    def action_wrapper(*args, **kws):
-        with ActionContext(_fn):
-            res = _fn(*args, **kws)
+    def __new__(cls, _fn=None, **kws):
+        if _fn is None:
+            return lambda _fn: action(_fn, **kws)
+        return _fn if IS_SERVER_SIDE else object.__new__(cls)
+
+    def __init__(self, _fn, **kws):
+        for k, v in kws.items():
+            setattr(_fn, k, v)
+        self._set_atom_prop(_fn)
+        self.f = _fn
+
+    def _set_atom_prop(self, _fn):
+        if type(_fn) is not MethodType:
+            _fn.atom = None
+            return
+        atom = _fn.__self__
+        if is_atom(atom):
+            _fn.atom = atom
+        else:
+            _fn.atom = None
+
+    def __call__(self, args, kws):
+        with ActionContext(self.f):
+            res = self.f(*args, **kws)
         return res
 
-    return _fn if IS_SERVER_SIDE else action_wrapper
+    def __get__(self, obj, cls=None):
+        if obj is None:
+            return self
+        return action(self.f.__get__(obj, cls))
 
 
 def subscribe(f):

--- a/client_code/atomic/utils.py
+++ b/client_code/atomic/utils.py
@@ -25,4 +25,4 @@ MethodType = type(_C()._m)
 
 
 def is_atom(atom):
-    return type(atom) is not type and hasattr(atom, REGISTRAR)
+    return hasattr(type(atom), "__is_atom__")

--- a/client_code/atomic/utils.py
+++ b/client_code/atomic/utils.py
@@ -4,6 +4,9 @@
 __version__ = "0.0.1"
 
 
+from .constants import REGISTRAR
+
+
 def get_atom_prop_repr(atom, prop):
     tp_name = type(atom).__name__
     if isinstance(atom, dict):
@@ -19,3 +22,7 @@ class _C:
 
 
 MethodType = type(_C()._m)
+
+
+def is_atom(atom):
+    return type(atom) is not type and hasattr(atom, REGISTRAR)

--- a/docs/guides/modules/atomic.rst
+++ b/docs/guides/modules/atomic.rst
@@ -221,7 +221,23 @@ Here's an example.
             indexed_db["todos"] = todos_atom.todos
 
 
+The ``@action`` decorator can be used on any function or method.
+If the decorator is used above a method then the ``atom`` used as the ``self`` argument
+can be caught within a ``subscribe`` function
 
+.. code-block:: python
+
+    @subscribe
+    def update_db_subscriber(actions):
+        for action in actions:
+            if hasattr(action, "update_db"):
+                atom = action.atom
+                break
+        else:
+            return
+
+        # now use the atom do do something specific
+        ...
 
 
 Bindings and Writeback


### PR DESCRIPTION
We could do something where the `action` is the thing that gets passed to the `with ActionContext` rather than `self.f`
(on line 71 in the new world - line 54 in the old world)

that might be nicer
But since we already passed the function I didn't change that

feel free to tag a commit onto this one to make that happen
and or make it work - this pr is untested

