### PR TITLE
Non blocking

### DIFF
--- a/docs/guides/modules/atomic.rst
+++ b/docs/guides/modules/atomic.rst
@@ -237,11 +237,11 @@ can be caught within a ``subscribe`` function
         else:
             return
 
-        # now use the atom do do something specific
+        # now use the atom to do something specific
         ...
 
 
-Alternave Approaches to the subscriber
+Alternative Approaches to the subscriber
 
 .. code-block:: python
 
@@ -254,7 +254,7 @@ Alternave Approaches to the subscriber
 
         todos = [dict(todo) for todo in todos_atom.todos]
         # accessing the todos and each converting each todo to a dict
-        # creates a depenency on the todos and each key of each todo
+        # creates a dependency on the todos and each key of each todo
         # whenever these change this method is called
 
         if is_first_run:
@@ -396,7 +396,7 @@ API
     Calling ``autorun`` returns a dispose function.
     When the dispose function is called it stops any future renders of this ``autorun`` function.
 
-    ``autorun`` can be used as a decorator - but note that the returned function is not the original function but the dipsose function.
+    ``autorun`` can be used as a decorator - but note that the returned function is not the original function but the dispose function.
 
 
 .. function:: reaction(depends_on_fn, then_react_fn)
@@ -412,11 +412,12 @@ API
     To call the ``then_react_fn`` immediately set ``fire_immediately=True``.
 
     It would be rare to need to use this function.
-    However in cases where you want to react to a change in an atom's state
-    that may result in subsquent change in another atom's state a reaction may be useful.
+
+    However, in cases where you want to react to a change in an atom's state
+    that may result in a subsequent change, in another atom's state a reaction may be useful.
     It can also be used as an alternative to ``autorun`` or ``render``.
 
-    See the example above for alternative approaches to upating ``indexed_db``
+    See the example above for alternative approaches to updating ``indexed_db``
 
     The reaction method returns a dispose function that can be called when you want to stop reactions.
 

--- a/docs/guides/modules/non_blocking.rst
+++ b/docs/guides/modules/non_blocking.rst
@@ -43,18 +43,23 @@ If you care about the return value, you can provide handlers.
     def update_database(self, **event_args):
         call_server_async("update", self.item).on_result(self.handle_result, self.handle_error)
         # Equivalent to
-        _ = call_server_async("update", self.item)
-        _.on_result(self.handle_result, self.handle_result)
+        async_call = call_server_async("update", self.item)
+        async_call.on_result(self.handle_result, self.handle_result)
         # Equivalent to
-        _ = call_server_async("update", self.item)
-        _.on_result(self.handle_result)
-        _.on_error(self.handle_error)
+        async_call = call_server_async("update", self.item)
+        async_call.on_result(self.handle_result)
+        async_call.on_error(self.handle_error)
 
 
 Interval
 ********
 
 Create a Timer-like object in code without worrying about components.
+
+The function will run repeatedly after each delay.
+This means setting the delay to 0 will cause the function to run every 0 seconds 😬.
+To kill the Interval set the delay to None or call the ``clear()`` method.
+
 
 .. code-block:: python
 
@@ -63,14 +68,45 @@ Create a Timer-like object in code without worrying about components.
     i = 0
     def do_heartbeat():
         global heartbeat, i
-        if i >= 100:
-            heartbeat.interval = 0
+        if i >= 42:
+            heartbeat.delay = None
+            # equivalent to heartbeat.clear()
         print("da dum")
         i += 1
 
-    heartbeat = Interval(do_heartbeat, 1)
+    heartbeat = Interval(do_heartbeat, delay=1)
 
 
+Timeout
+********
+
+Create a Timer-like object in code without worrying about components.
+A timeout will only run once after the delay.
+To kill the Timeout set the delay to ``None`` or call the ``clear()`` method.
+
+A Timeout is particularly useful for pending saves
+
+.. code-block:: python
+
+    from anvil_labs.non_blocking import Interval
+
+    pending = []
+
+    def do_save():
+        global pending
+        pending, saves = [], pending
+        if not saves:
+            return
+        anvil.server.call_s("save", saves)
+
+    save_timeout = Timeout(do_save)
+
+    def on_save(saves):
+        global pending
+        pending.extend(saves)
+        save_timeout.delay = 1
+
+    # calling on_save repeatedly will reset the delay to do_save
 
 
 API
@@ -107,21 +143,60 @@ API
 
         Returns ``self``.
 
-    .. method:: wait(self)
+    .. method:: await_reslt(self)
 
         Waits for the non-blocking call to finish executing and returns the result.
+        Or raises an exception if the non-blocking call raised an exception.
+
+    .. property:: result
+
+        If the non-blocking call has not yet completed, returns a Javascript Promise.
+        This can be awaited using ``anvil.js.await_promise``
+
+        If the non_blocking call has completed returns the result.
+        Or raises an exception if the non-blocking call raised an exception.
+
+    .. property:: error
+
+        If the non-blocking call raised an exception the exception raised can be accessed using the ``error`` property
+
+    .. property:: set_status
+
+        One of ``"PENDING"``, ``"FULFILLED"``, ``"REJECTED"``
 
 
-.. class:: Interval(fn, interval=None)
+.. class:: Interval(fn, delay=None)
 
     Create an interval that will call a function every delay seconds.
-    If the delay is ``0`` or ``None`` the Interval will stop calling the function.
+    If the delay is ``None`` the Interval will stop calling the function.
 
-    .. attribute:: interval
+    A delay of ``0`` means the function will be called every 0 seconds!
+
+    Functions executed by an interval are non-blocking.
+
+    .. attribute:: delay
 
         change the interval to ``None`` or an ``int`` / ``float`` in seconds.
-        If the interval is ``None`` or ``0``, the function will no longer fire.
+        If the delay is ``None``, the function will no longer fire.
 
-    .. method:: clear_interval(self)
+    .. method:: clear(self)
 
-        Equivalent to ``my_interval.interval = None``
+        Equivalent to ``my_interval.delay = None``
+
+.. class:: Timeout(fn, delay=None)
+
+    Create a timeout that will call a function after delay seconds.
+    If the delay is ``None`` the timeout will stop calling the function.
+
+    A delay of ``0`` means the function will be called immediately!
+
+    Functions executed by a timeout are non-blocking.
+
+    .. attribute:: delay
+
+        change the interval to ``None`` or an ``int`` / ``float`` in seconds.
+        If the delay is ``None``, the function will no longer fire.
+
+    .. method:: clear(self)
+
+        Equivalent to ``my_timeout.delay = None``


### PR DESCRIPTION
Some updates and breaking changes
**updates**
- async call objects now have a `.result`, `.error` and `.status` property
- `wait` -> `await_result`.
- tried to make the logic for `on_result()` and `on_error()` clearer by moving it to JS.
- added some client tests to the end of the module

**breaking changes:**
- Interval - the `.interval` property was replaced by `.delay`
  - this means that setting `delay = 0` causes the interval function to run every 0 seconds
- Interval `clear_interval()` -> `clear()`

The breaking changes are there for consistency between `Timeout` and `Interval`.

I can make this backward compatible. 
But I think the number of users affected by these changes might be close to zero.
