### PR TITLE
Reactions

### DIFF
--- a/client_code/atomic/decorators.py
+++ b/client_code/atomic/decorators.py
@@ -146,7 +146,6 @@ def reaction(
     *,
     fire_immediately=False,
     include_previous=False,
-    **options
 ):
     """a reaction takes two arguments: depends_on_fn and then_react_fn
     the depends_on_fn is used to determine the dependcies that the then_react_fn depends on
@@ -164,6 +163,5 @@ def reaction(
         then_react_fn,
         fire_immediately=fire_immediately,
         include_previous=include_previous,
-        **options
     )
     return r.dispose

--- a/client_code/atomic/decorators.py
+++ b/client_code/atomic/decorators.py
@@ -140,7 +140,14 @@ def autorun(f, bound=None):
     return r.dispose
 
 
-def reaction(depends_on_fn, then_react_fn, fire_immediately=False, **options):
+def reaction(
+    depends_on_fn,
+    then_react_fn,
+    *,
+    fire_immediately=False,
+    include_previous=False,
+    **options
+):
     """a reaction takes two arguments: depends_on_fn and then_react_fn
     the depends_on_fn is used to determine the dependcies that the then_react_fn depends on
     when ever an atom attribute accessed in the depends_on_fn changes the then_react_fn is called.
@@ -153,6 +160,10 @@ def reaction(depends_on_fn, then_react_fn, fire_immediately=False, **options):
     Returns: a dispose function - when called stops any future reactions
     """
     r = Reaction(
-        depends_on_fn, then_react_fn, fire_immediately=fire_immediately, **options
+        depends_on_fn,
+        then_react_fn,
+        fire_immediately=fire_immediately,
+        include_previous=include_previous,
+        **options
     )
     return r.dispose

--- a/client_code/atomic/subscribers.py
+++ b/client_code/atomic/subscribers.py
@@ -151,12 +151,10 @@ class Reaction(Subscriber):
         *,
         fire_immediately=False,
         include_previous=False,
-        **options,
     ):
         super().__init__()
         self.depends_on = depends_on
         self.then_react = then_react
-        self.options = options
         self.previous = None
         self.include_previous = include_previous
         if fire_immediately:

--- a/client_code/atomic/subscribers.py
+++ b/client_code/atomic/subscribers.py
@@ -149,7 +149,7 @@ class Reaction(Subscriber):
         depends_on,
         then_react,
         *,
-        fire_immediatly=False,
+        fire_immediately=False,
         include_previous=False,
         **options,
     ):
@@ -159,7 +159,7 @@ class Reaction(Subscriber):
         self.options = options
         self.previous = None
         self.include_previous = include_previous
-        if fire_immediatly:
+        if fire_immediately:
             return self.react()
         with ReactionContext(self):
             self.previous = self.depends_on()

--- a/client_code/atomic/subscribers.py
+++ b/client_code/atomic/subscribers.py
@@ -144,20 +144,33 @@ class Reaction(Subscriber):
 
     mode = REACTION
 
-    def __init__(self, depends_on, then_react, fire_immediatly=False, **options):
+    def __init__(
+        self,
+        depends_on,
+        then_react,
+        *,
+        fire_immediatly=False,
+        include_previous=False,
+        **options,
+    ):
         super().__init__()
         self.depends_on = depends_on
         self.then_react = then_react
         self.options = options
+        self.previous = None
+        self.include_previous = include_previous
         if fire_immediatly:
             return self.react()
         with ReactionContext(self):
-            self.depends_on()
+            self.previous = self.depends_on()
 
     def react(self):
         with ReactionContext(self):
             res = self.depends_on()
-        if res is not None:
+        prev, self.previous = self.previous, res
+        if self.include_previous:
+            self.then_react(res, prev)
+        elif res is not None:
             self.then_react(res)
         else:
             self.then_react()

--- a/docs/guides/modules/atomic.rst
+++ b/docs/guides/modules/atomic.rst
@@ -399,17 +399,21 @@ API
     ``autorun`` can be used as a decorator - but note that the returned function is not the original function but the dispose function.
 
 
-.. function:: reaction(depends_on_fn, then_react_fn)
-              reaction(depends_on_fn, then_react_fn, fire_immediately=False)
+.. function:: reaction(depends_on_fn, then_react_fn, *, fire_immediately=False, include_previous=False)
 
     a ``reaction`` is similar to a ``render``.
     Changes in the ``depends_on_fn`` will force the ``then_react_fn`` to be called.
     The ``depends_on_fn`` is a function that takes no args.
     It should access any attributes that, when changed, should result in the call to the ``then_react_fn``.
+
     If ``depends_on_fn`` returns a value that is not ``None``, this value will be passed to the ``then_react_fn``.
+    If you need the previous result returned from ``depends_on_fn`` set ``include_previous=True``.
+    If ``incldue_previous`` is ``True`` then the call signature for ``then_react_fn`` should take 2 argments,
+    the current return value and the previous return value from the ``depnds_on_fn``.
 
     ``depends_on_fn`` will fire immediately. But the ``then_react_fn`` is only called the next time a dependency changes.
     To call the ``then_react_fn`` immediately set ``fire_immediately=True``.
+
 
     It would be rare to need to use this function.
 


### PR DESCRIPTION
This is based on the arguments to mobx reaction: https://mobx.js.org/reactions.html#reaction
I can see having the previous result being useful when you want to compare the previous result to the current result returned from the `depends_on_fn`

