### PR TITLE
some more non-blocking tweaks

### DIFF
--- a/docs/guides/modules/non_blocking.rst
+++ b/docs/guides/modules/non_blocking.rst
@@ -150,15 +150,17 @@ API
 
     .. property:: result
 
-        If the non-blocking call has not yet completed, returns a Javascript Promise.
-        This can be awaited using ``anvil.js.await_promise``
+        If the non-blocking call has not yet completed, raise a ``RuntimeError``.
 
         If the non_blocking call has completed returns the result.
         Or raises an exception if the non-blocking call raised an exception.
 
     .. property:: error
 
-        If the non-blocking call raised an exception the exception raised can be accessed using the ``error`` property
+        If the non-blocking call has not yet completed, raise a ``RuntimeError``.
+
+        If the non-blocking call raised an exception the exception raised can be accessed using the ``error`` property.
+        The error will be ``None`` if the non-blocking call returned a result.
 
     .. property:: set_status
 

--- a/docs/guides/modules/non_blocking.rst
+++ b/docs/guides/modules/non_blocking.rst
@@ -143,7 +143,7 @@ API
 
         Returns ``self``.
 
-    .. method:: await_reslt(self)
+    .. method:: await_result(self)
 
         Waits for the non-blocking call to finish executing and returns the result.
         Or raises an exception if the non-blocking call raised an exception.


### PR DESCRIPTION
Bug fix:
Because we're using js interop, if an asyn call returns a dictionary - this will get converted to a javascript object and will then be returned as a proxy object.
We don't want that so instead wrap the return value in a more opaque python class that won't be subject to the same javascript <-> python dance.

Changes:
Raise a RuntimeError if trying to access the result/error from a promise before it has fulfilled.
Trying to use the result property before the function has returned is a recipe for disaster.
We're not Javascript so we should raise an exception.

Use `anvil.js.report_exceptions` to wrap the error/result handlers.
Currently if the ``result_handler`` raises an exception this exception would get passed to the ``on_error`` handler.
We don't want that. The ``on_error`` handler should be exclusively for errors thrown by the function that was called asynchronously.

