### PR TITLE
non-blocking: simplify api - call_async only

### DIFF
--- a/client_code/non_blocking.py
+++ b/client_code/non_blocking.py
@@ -128,18 +128,18 @@ class _AsyncCall:
 _AsyncCall.wait = _AsyncCall.await_result
 
 
-def call_async(fn, *args, **kws):
-    "call a function in a non-blocking way"
-    if not callable(fn):
-        raise TypeError("the first argument must be a callable")
-    return _AsyncCall(fn, *args, **kws)
+def call_async(fn_or_name, *args, **kws):
+    "call a function, or server function in a non-blocking way"
+    if isinstance(fn_or_name, str):
+        return _AsyncCall(_call_s, fn_or_name, *args, **kws)
+    if callable(fn_or_name):
+        return _AsyncCall(fn_or_name, *args, **kws)
+    msg = "the first argument must be a callable or the name of a server function"
+    raise TypeError(msg)
 
 
-def call_server_async(fn_name, *args, **kws):
-    "call a server function in a non_blocking way"
-    if not isinstance(fn_name, str):
-        raise TypeError("the first argument must be the server function name as a str")
-    return _AsyncCall(_call_s, fn_name, *args, **kws)
+# Backward compatability - remove at some point
+call_server_async = call_async
 
 
 def wait_for(async_call_object):

--- a/docs/guides/modules/non_blocking.rst
+++ b/docs/guides/modules/non_blocking.rst
@@ -88,7 +88,7 @@ A Timeout is particularly useful for pending saves
 
 .. code-block:: python
 
-    from anvil_labs.non_blocking import Interval
+    from anvil_labs.non_blocking import Timeout
 
     pending = []
 

--- a/docs/guides/modules/non_blocking.rst
+++ b/docs/guides/modules/non_blocking.rst
@@ -15,7 +15,7 @@ In this example, we don't care about the return.
 
 .. code-block:: python
 
-    from anvil_labs.non_blocking import call_server_async
+    from anvil_labs.non_blocking import call_async
 
     def button_click(self, **event_args):
         self.update_database()
@@ -23,14 +23,14 @@ In this example, we don't care about the return.
 
     def update_database(self):
         # Unlike anvil.server.call we do not wait for the call to return
-        call_server_async("update", self.item)
+        call_async("update", self.item)
 
 
 If you care about the return value, you can provide handlers.
 
 .. code-block:: python
 
-    from anvil_labs.non_blocking import call_server_async
+    from anvil_labs.non_blocking import call_async
 
     def handle_result(self, res):
         print(res)
@@ -41,12 +41,12 @@ If you care about the return value, you can provide handlers.
         Notification("there was a problem", style="danger").show()
 
     def update_database(self, **event_args):
-        call_server_async("update", self.item).on_result(self.handle_result, self.handle_error)
+        call_async("update", self.item).on_result(self.handle_result, self.handle_error)
         # Equivalent to
-        async_call = call_server_async("update", self.item)
+        async_call = call_async("update", self.item)
         async_call.on_result(self.handle_result, self.handle_error)
         # Equivalent to
-        async_call = call_server_async("update", self.item)
+        async_call = call_async("update", self.item)
         async_call.on_result(self.handle_result)
         async_call.on_error(self.handle_error)
 
@@ -113,12 +113,11 @@ API
 ---
 
 .. function:: call_async(fn, *args, **kws)
+              call_async(fn_name, *args, **kws)
 
     Returns an ``AyncCall`` object. The *fn* will be called in a non-blocking way.
 
-.. function:: call_server_async(fn_name, *args, **kws)
-
-    Returns an ``AyncCall`` object. The server function will be called in a non-blocking way.
+    If the first argument is a string then the server function with name *fn_name* will be called in a non-blocking way.
 
 .. function:: wait_for(async_call_object)
 


### PR DESCRIPTION
related to #70 

Just remove `call_server_async`
I think most people will want to only use it for this purpose.
So let `call_async` accept either a callable or a str and do the obvious thing depending on the type of the argument.